### PR TITLE
feat: add a retry - timeout logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ MBTF_FILES:=$(shell find $(MBTF_FOLDER) -type f -name '*.go')
 PROVIDER_BINARY:=terraform-provider-metabase
 MBTF_BINARY:=mbtf
 TEST_API_KEY_FILE=.test-api-key
+METABASE_SETTING_WAIT_TIMEOUT:=15s
 
 set-up-docker:
 	./test-docker.sh

--- a/internal/provider/setting_resource.go
+++ b/internal/provider/setting_resource.go
@@ -173,6 +173,40 @@ func (r *SettingResource) handleSettingResponse(ctx context.Context, updateResp 
 	return nil
 }
 
+// waitForSettingUpdate polls Metabase until the setting matches the desired value or timeout is reached.
+func (r *SettingResource) waitForSettingUpdate(ctx context.Context, key, want string, timeout time.Duration) error {
+    const pollInterval = 2 * time.Second
+    deadline := time.Now().Add(timeout)
+
+    for {
+        // Fetch current value
+        getResp, err := r.client.GetSettingWithResponse(ctx, key)
+        if err != nil {
+            return fmt.Errorf("failed to poll setting: %w", err)
+        }
+        if getResp.StatusCode() == 200 && getResp.JSON200 != nil {
+            // Convert value to string for comparison
+            var current string
+            if jsonBytes, err := json.Marshal(*getResp.JSON200); err == nil {
+                current = string(jsonBytes)
+            } else {
+                current = fmt.Sprintf("%v", *getResp.JSON200)
+            }
+            // Try to normalize JSON if possible
+            if normalized, err := normalizeJSON(current); err == nil {
+                current = normalized
+            }
+            if current == want {
+                return nil // Success
+            }
+        }
+        if time.Now().After(deadline) {
+            return fmt.Errorf("timeout waiting for setting %q to be applied", key)
+        }
+        time.Sleep(pollInterval)
+    }
+}
+
 func (r *SettingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data *SettingResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -194,6 +228,11 @@ func (r *SettingResource) Create(ctx context.Context, req resource.CreateRequest
 		resp.Diagnostics.AddError("Failed to handle setting response", err.Error())
 		return
 	}
+
+    // Poll until the setting is applied or timeout (e.g., 30s)
+    if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 30*time.Second); err != nil {
+        resp.Diagnostics.AddWarning("Setting propagation delay", err.Error())
+    }
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -249,6 +288,11 @@ func (r *SettingResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Failed to handle setting response", err.Error())
 		return
 	}
+	
+    // Poll until the setting is applied or timeout (e.g., 30s)
+    if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 30*time.Second); err != nil {
+        resp.Diagnostics.AddWarning("Setting propagation delay", err.Error())
+    }
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/setting_resource.go
+++ b/internal/provider/setting_resource.go
@@ -237,7 +237,7 @@ func (r *SettingResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
     // Poll until the setting is applied or timeout (e.g., 30s)
-    if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 120*time.Second); err != nil {
+    if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 10*time.Second); err != nil {
         resp.Diagnostics.AddWarning("Setting propagation delay", err.Error())
     }
 
@@ -297,7 +297,7 @@ func (r *SettingResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
     // Poll until the setting is applied or timeout (e.g., 30s)
-    if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 120*time.Second); err != nil {
+    if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 10*time.Second); err != nil {
         resp.Diagnostics.AddWarning("Setting propagation delay", err.Error())
     }
 

--- a/internal/provider/setting_resource.go
+++ b/internal/provider/setting_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -288,7 +289,7 @@ func (r *SettingResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Failed to handle setting response", err.Error())
 		return
 	}
-	
+
     // Poll until the setting is applied or timeout (e.g., 30s)
     if err := r.waitForSettingUpdate(ctx, data.Key.ValueString(), data.Value.ValueString(), 30*time.Second); err != nil {
         resp.Diagnostics.AddWarning("Setting propagation delay", err.Error())


### PR DESCRIPTION
Add a retry/timeout logic to let metabase apply changes before testing drift.